### PR TITLE
Update clean.py

### DIFF
--- a/clean.py
+++ b/clean.py
@@ -50,7 +50,7 @@ def write_file(output_path, root):
 def append_mms(mms_list, root):
     log.debug("Adding skipped %d MMS into new XML..." % len(mms_list))
     for mms in mms_list:
-        root.append(mms)
+        root.extend(mms)
 
 
 def add_sms(conn, root):


### PR DESCRIPTION
Fixes "TypeError: must be Element, not lxml.etree._Element" seen when trying to merge mms back into the XML file
(changed .append to .extend)